### PR TITLE
Improve several permission description Strings.

### DIFF
--- a/cm/res/AndroidManifest.xml
+++ b/cm/res/AndroidManifest.xml
@@ -36,7 +36,7 @@
                 android:icon="@drawable/ic_launcher_cyanogenmod"
                 android:protectionLevel="normal" />
 
-    <!-- Allows system applications to make changes to a subset of system network settings -->
+    <!-- Allows an app to make changes to the airplane mode and mobile data network settings -->
     <permission android:name="cyanogenmod.permission.MODIFY_NETWORK_SETTINGS"
                 android:label="@string/permlab_modifyNetworkSettings"
                 android:description="@string/permdesc_modifyNetworkSettings"
@@ -44,7 +44,7 @@
                 androidprv:allowViaWhitelist="true"
                 android:protectionLevel="system|signature" />
 
-    <!-- Allows system applications to make changes to a subset of system sound settings -->
+    <!-- Allows an app to make changes to the interruption mode sound settings -->
     <permission android:name="cyanogenmod.permission.MODIFY_SOUND_SETTINGS"
                 android:label="@string/permlab_modifySoundSettings"
                 android:description="@string/permdesc_modifySoundSettings"

--- a/cm/res/res/values/strings.xml
+++ b/cm/res/res/values/strings.xml
@@ -22,10 +22,10 @@
     <string name="permdesc_publishCustomTile">Allows an app to publish a quick settings tile.</string>
 
     <string name="permlab_modifyNetworkSettings">change system network settings</string>
-    <string name="permdesc_modifyNetworkSettings">Allows an app to make changes to a restricted set of system network settings.</string>
+    <string name="permdesc_modifyNetworkSettings">Allows an app to make changes to the airplane mode and mobile data network settings.</string>
 
     <string name="permlab_modifySoundSettings">change system sound settings</string>
-    <string name="permdesc_modifySoundSettings">Allows an app to make changes to a restricted set of system sound settings.</string>
+    <string name="permdesc_modifySoundSettings">Allows an app to make changes to the interruption mode sound settings.</string>
 
     <string name="permlab_bindCustomTileListenerService">bind to a custom tile listener service</string>
     <string name="permdesc_bindCustomTileListenerService">Allows the app to bind to the top-level interface of a custom tile listener service.</string>


### PR DESCRIPTION
The MODIFY_NETWORK_SETTINGS and MODIFY_SOUND_SETTINGS permissions were
not descriptive enough. Improve the strings to enumerate exactly what
settings these permissions protect.

Fixes FOR-23.

Change-Id: Idd64738c21d879462a7e7e6c65ceefdc771f1bcd