### PR TITLE
HighTouchSensitivity [1/2]: Add Settings preference

### DIFF
--- a/src/java/cyanogenmod/providers/CMSettings.java
+++ b/src/java/cyanogenmod/providers/CMSettings.java
@@ -596,6 +596,14 @@ public final class CMSettings {
         public static final String NOTIFICATION_PLAY_QUEUE = "notification_play_queue";
 
         /**
+         * Whether the HighTouchSensitivity is activated or not.
+         * 0 = off, 1 = on
+         * @hide
+         */
+        public static final String HIGH_TOUCH_SENSITIVITY_ENABLE =
+                "high_touch_sensitivity_enable";
+
+        /**
          * Show the pending notification counts as overlays on the status bar
          * @hide
          */


### PR DESCRIPTION
 * Allows the HighTouchSensitivity (Glove mode)
   value to be saved in the CMSettings provider

 * Can be used in a device specific service to handle
   the Glove mode in a way closer to the device's vendor

 * Changes include :
     android_packages_apps_Settings
     cm_platform_sdk

Change-Id: Ib3cb8c4c67fb2397136ccfdf08cd8e7d938e898d
Signed-off-by: AdrianDC <radian.dc@gmail.com>