### PR TITLE
CMSettingsProvider: Only enable component if already disabled.

### DIFF
--- a/packages/CMSettingsProvider/src/org/cyanogenmod/cmsettings/CMSettingsProvider.java
+++ b/packages/CMSettingsProvider/src/org/cyanogenmod/cmsettings/CMSettingsProvider.java
@@ -265,13 +265,16 @@ public class CMSettingsProvider extends ContentProvider {
 
         boolean hasMigratedCMSettings = mSharedPrefs.getBoolean(PREF_HAS_MIGRATED_CM_SETTINGS,
                 false);
-        if (!hasMigratedCMSettings) {
+        final ComponentName preBootReceiver = new ComponentName("org.cyanogenmod.cmsettings",
+                "org.cyanogenmod.cmsettings.PreBootReceiver");
+        final PackageManager packageManager = getContext().getPackageManager();
+        if (!hasMigratedCMSettings &&
+                packageManager.getComponentEnabledSetting(preBootReceiver)
+                        == PackageManager.COMPONENT_ENABLED_STATE_DISABLED ) {
             if (LOCAL_LOGV) {
                 Log.d(TAG, "Reenabling component preboot receiver");
             }
-            getContext().getPackageManager().setComponentEnabledSetting(
-                    new ComponentName("org.cyanogenmod.cmsettings",
-                            "org.cyanogenmod.cmsettings.PreBootReceiver"),
+            packageManager.setComponentEnabledSetting(preBootReceiver,
                     PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
                     PackageManager.DONT_KILL_APP);
         }


### PR DESCRIPTION
  Each CALL method would renable and already enabled component,
  cut down on log spam.

Change-Id: Ie58c75e32c828b1ce8b1017620b5a3b073830bbd